### PR TITLE
Correction in exercise 09-throw-an-error

### DIFF
--- a/src/09-throw-an-error.js
+++ b/src/09-throw-an-error.js
@@ -11,4 +11,4 @@ function parsedPromised(json) {
 
 parsedPromised(process.argv[2])
 .then(console.log)
-.catch(console.log)
+.catch(error => console.log(error.message))


### PR DESCRIPTION
There is a correction on exercise 09 solution.
It should print error message nor error